### PR TITLE
TASK: Define more space for iPhoneX

### DIFF
--- a/app/NeosCon.js
+++ b/app/NeosCon.js
@@ -27,6 +27,9 @@ AsyncStorage.getItem("@NeosCon.state").then(
   }
 );
 
+// define light status bar for whole app
+StatusBar.setBarStyle("light-content", true);
+
 const App = StackNavigator(
   {
     Home: {

--- a/app/scenes/Schedule/index.js
+++ b/app/scenes/Schedule/index.js
@@ -20,6 +20,7 @@ import Break from "./components/Break";
 import Talk from "./components/Talk";
 import { TIME_FORMAT } from "../../constants";
 import { ScheduleTalk } from "../../types";
+import theme from "../../theme";
 
 import talks from "../../data/talks";
 import Navbar from "../../components/Navbar";
@@ -75,10 +76,8 @@ export default class Schedule extends Component {
       // This isn't relevant on Android.
       this.scrollYListener = this.state.scrollY.addListener(({ value }) => {
         if (value > 120) {
-          StatusBar.setBarStyle("default", true);
           StatusBar.setHidden(false, true);
         } else if (value < 80) {
-          StatusBar.setBarStyle("light-content", true);
           StatusBar.setHidden(false, true);
         } else {
           StatusBar.setHidden(true, true);
@@ -116,15 +115,9 @@ export default class Schedule extends Component {
   };
   handleNavigatorWillFocus = (event: any) => {
     const { scene } = event.data.route;
-
-    if (scene === "Schedule" && this.state.scrollY._value < 120) {
-      StatusBar.setBarStyle("light-content", true);
-    }
-
     this.setState({ now: new Date() });
   };
   gotoEventInfo = () => {
-    StatusBar.setBarStyle("default", true);
     this.props.navigation.navigate("Info");
   };
 
@@ -161,7 +154,6 @@ export default class Schedule extends Component {
     }
 
     const onPress = () => {
-      StatusBar.setBarStyle("default", true);
       if (!item.shouldShowDetails) {
         return;
       }
@@ -190,10 +182,9 @@ export default class Schedule extends Component {
     const { dataSource, scrollY, showNowButton } = this.state;
 
     const isAndroid = Platform.OS === "android";
-
     const navbarTop = scrollY.interpolate({
       inputRange: [80, 120],
-      outputRange: [-64, 0],
+      outputRange: [-theme.navbar.height, 0],
       extrapolate: "clamp"
     });
 

--- a/app/theme.js
+++ b/app/theme.js
@@ -43,11 +43,17 @@ const fontSize = {
 // Component Specific
 // ------------------------------
 
+const isIphoneX = () => {
+  let d = Dimensions.get("window");
+  const { height, width } = d;
+  return Platform.OS === "ios" && (height === 812 || width === 812);
+};
+
 // navbar
 const navbar = {
   backgroundColor: color.darkBlue,
   buttonColor: color.blue,
-  height: 64,
+  height: isIphoneX() ? 84 : 64,
   textColor: color.lightText
 };
 
@@ -71,5 +77,6 @@ export default {
   nextup,
   listheader,
   talkPaneAndroidMinScrollAreaHeight,
-  statusBarHeight
+  statusBarHeight,
+  isIphoneX
 };


### PR DESCRIPTION
Making the navigation bar on the iphone x bit higher and use
always thr bright status bar.

Also tried the SafeAreaView from react native for that but we need to adjust a bit more then. For instance the background is then also for the bottom safeArea and so on.

So this is more a quick fix to make it easier to use on the iPhone X.

Thank to @jonnitto for reporting that :)