### PR TITLE
Bugfix prevent crashes

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "privacy": "unlisted",
     "sdkVersion": "32.0.0",
     "platforms": ["ios", "android"],
-    "version": "1.1.0",
+    "version": "1.1.2",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {
@@ -29,7 +29,7 @@
     "android": {
       "package": "de.sandstorm.neosconference",
       "permissions": [],
-      "versionCode": 1557343680
+      "versionCode": 1557349461
     },
     "androidStatusBar": {
       "backgroundColor": "#26224C"

--- a/app/scenes/Talk/components/Speaker/index.js
+++ b/app/scenes/Talk/components/Speaker/index.js
@@ -6,8 +6,7 @@ import {
   Text,
   TouchableHighlight,
   TouchableOpacity,
-  View,
-  SafeAreaView
+  View
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
 
@@ -16,6 +15,7 @@ import DraggableView from '../../../../components/DraggableView';
 import Modal from '../../../../components/Modal';
 import theme from '../../../../theme';
 import { attemptToOpenUrl } from '../../../../utils';
+import { Platform } from 'expo-core';
 
 function Button({ bordered, icon, onPress, text }) {
   const touchableProps = {
@@ -30,9 +30,14 @@ function Button({ bordered, icon, onPress, text }) {
     borderLeftWidth: bordered ? 1 / PixelRatio.get() : null
   };
 
+  const mergedStyles = [styles.button];
+  if (Platform.OS === 'ios') {
+    mergedStyles.push(dynamicStyles);
+  }
+
   return (
     <TouchableHighlight {...touchableProps}>
-      <View style={[styles.button, dynamicStyles]}>
+      <View style={mergedStyles}>
         <Icon name={icon} size={24} style={styles.buttonIcon} />
         <Text style={styles.buttonText}>{text}</Text>
       </View>


### PR DESCRIPTION
The app crashes caused by a missing view manager.
The borderLeftColor property leads to that error.